### PR TITLE
Fix leaderboard layout issues

### DIFF
--- a/frontend/src/components/Leaderboard.jsx
+++ b/frontend/src/components/Leaderboard.jsx
@@ -30,11 +30,11 @@ function Leaderboard() {
   }
 
   const CategoryCard = ({ title, players, color, description }) => (
-    <div className="nes-container with-title bg-white overflow-hidden">
-      <p className="title" style={{ color }}>{title}</p>
+    <div className="nes-container bg-white">
+      <h3 className="font-bold text-lg mb-2" style={{ color }}>{title}</h3>
       <p className="text-xs text-gray-600 mb-4">{description}</p>
       
-      <div className="space-y-3 max-h-96 overflow-y-auto">
+      <div className="space-y-3">
         {players.map((player, index) => (
           <div 
             key={player.rank} 


### PR DESCRIPTION
- Remove NES.css with-title class that causes spacing problems
- Remove max-height and overflow scroll from player lists
- Use standard h3 heading for better spacing control
- Clean up layout for 5 players per league